### PR TITLE
feat: apply external forms config

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -63,6 +63,8 @@ module.exports = {
     'import/prefer-default-export': 'off',
     'object-curly-newline': 'off',
     'arrow-parens': [2, 'always'],
+    'template-curly-spacing': 'off',
+    indent: 'off',
   },
 
   env: {

--- a/src/classes/elements/Popup.js
+++ b/src/classes/elements/Popup.js
@@ -6,7 +6,6 @@ import { Button } from './Button';
 import closeIcon from '../../icons/close';
 import {
   applyExternalFormConfig,
-  getExternalFormData,
 } from '../../utils';
 
 export class Popup extends DOMObject {
@@ -247,8 +246,7 @@ export class Popup extends DOMObject {
       (element) => element instanceof Field || element instanceof Button
     );
     let isValid = true;
-    const externalData = getExternalFormData(this.data.formId) ?? {};
-    const data = { ...externalData };
+    const data = {};
     let button;
 
     if (elements) {

--- a/src/classes/elements/Popup.js
+++ b/src/classes/elements/Popup.js
@@ -4,6 +4,10 @@ import { Column } from './Column';
 import { Field } from './Field';
 import { Button } from './Button';
 import closeIcon from '../../icons/close';
+import {
+  applyExternalFormConfig,
+  getExternalFormData,
+} from '../../utils';
 
 export class Popup extends DOMObject {
   initialize() {
@@ -220,6 +224,9 @@ export class Popup extends DOMObject {
       }
       this.container.appendChild(this.el);
     }
+
+    applyExternalFormConfig({ element: this.el, formId: this.data.formId });
+
     this.trigger('sendsay-form-show', this.gainedData);
   }
 
@@ -240,7 +247,8 @@ export class Popup extends DOMObject {
       (element) => element instanceof Field || element instanceof Button
     );
     let isValid = true;
-    const data = {};
+    const externalData = getExternalFormData(this.data.formId) ?? {};
+    const data = { ...externalData };
     let button;
 
     if (elements) {

--- a/src/classes/elements/Popup.js
+++ b/src/classes/elements/Popup.js
@@ -4,9 +4,7 @@ import { Column } from './Column';
 import { Field } from './Field';
 import { Button } from './Button';
 import closeIcon from '../../icons/close';
-import {
-  applyExternalFormConfig,
-} from '../../utils';
+import { applyExternalFormConfig } from '../../utils';
 
 export class Popup extends DOMObject {
   initialize() {

--- a/src/utils/applyExternalFormConfig.js
+++ b/src/utils/applyExternalFormConfig.js
@@ -1,23 +1,22 @@
 const getExternalFormConfig = (formId) => {
-  if (!window.SENDSAY_FORMS || !formId) {
+  if (!window.SENDSAY_FORM_FIELDS || !formId) {
     return;
   }
 
-  return window.SENDSAY_FORMS[formId];
+  return window.SENDSAY_FORM_FIELDS[formId];
 };
 
 const createInputSelector = (fieldName) => `input[name="${fieldName}"]`;
 
-const hideFieldInput = (fieldName, element) => {
-  const input = element?.querySelector(createInputSelector(fieldName));
-  if (input) {
-    input.style.display = 'none';
+const hideFieldInput = (input) => {
+  const element = input;
+
+  if (element) {
+    element.style.display = 'none';
   }
 };
 
-const hideFieldLabel = (fieldName, element) => {
-  const input = element?.querySelector(createInputSelector(fieldName));
-
+const hideFieldLabel = (input) => {
   if (!input) {
     return;
   }
@@ -36,36 +35,25 @@ export const applyExternalFormConfig = ({ element, formId }) => {
     return;
   }
 
-  if (formConfig.email) {
-    const emailConfig = formConfig.email;
+  Object.keys(formConfig).forEach((fieldName) => {
+    const fieldConfig = formConfig[fieldName];
+    const input = element?.querySelector(createInputSelector(fieldName));
 
-    if (emailConfig.defaultValue !== undefined) {
-      const emailInputName = '_member_email';
-      const emailInput = element?.querySelector(createInputSelector(emailInputName));
-
-      if (emailInput) {
-        emailInput.value = emailConfig.defaultValue;
-
-        emailInput.dispatchEvent(new Event('input', { bubbles: true }));
-      }
-
-      if (emailConfig.hideInput) {
-        hideFieldInput(emailInputName, element);
-      }
-
-      if (emailConfig.hideLabel) {
-        hideFieldLabel(emailInputName, element);
-      }
+    if (!input) {
+      return;
     }
-  }
-};
 
-export const getExternalFormData = (formId) => {
-  const formConfig = getExternalFormConfig(formId);
+    if (fieldConfig.defaultValue !== undefined) {
+      input.value = fieldConfig.defaultValue;
+      input.dispatchEvent(new Event('input', { bubbles: true }));
+    }
 
-  if (!formConfig) {
-    return;
-  }
+    if (fieldConfig.hideInput) {
+      hideFieldInput(input);
+    }
 
-  return { ...formConfig.extraData };
+    if (fieldConfig.hideLabel) {
+      hideFieldLabel(input);
+    }
+  });
 };

--- a/src/utils/applyExternalFormConfig.js
+++ b/src/utils/applyExternalFormConfig.js
@@ -1,4 +1,4 @@
-export const getExternalFormConfig = (formId) => {
+const getExternalFormConfig = (formId) => {
   if (!window.SENDSAY_FORMS || !formId) {
     return;
   }
@@ -16,7 +16,6 @@ export const applyExternalFormConfig = ({ element, formId }) => {
   if (formConfig.email) {
     const emailConfig = formConfig.email;
 
-    // Set default value for email field
     if (emailConfig.defaultValue !== undefined) {
       const emailInputName = '_member_email';
       const emailInput = element?.querySelector(`input[name="${emailInputName}"]`);

--- a/src/utils/applyExternalFormConfig.js
+++ b/src/utils/applyExternalFormConfig.js
@@ -6,6 +6,29 @@ const getExternalFormConfig = (formId) => {
   return window.SENDSAY_FORMS[formId];
 };
 
+const createInputSelector = (fieldName) => `input[name="${fieldName}"]`;
+
+const hideFieldInput = (fieldName, element) => {
+  const input = element?.querySelector(createInputSelector(fieldName));
+  if (input) {
+    input.style.display = 'none';
+  }
+};
+
+const hideFieldLabel = (fieldName, element) => {
+  const input = element?.querySelector(createInputSelector(fieldName));
+
+  if (!input) {
+    return;
+  }
+
+  const label = input.parentElement?.querySelector('label');
+
+  if (label) {
+    label.style.display = 'none';
+  }
+};
+
 export const applyExternalFormConfig = ({ element, formId }) => {
   const formConfig = getExternalFormConfig(formId);
 
@@ -18,7 +41,7 @@ export const applyExternalFormConfig = ({ element, formId }) => {
 
     if (emailConfig.defaultValue !== undefined) {
       const emailInputName = '_member_email';
-      const emailInput = element?.querySelector(`input[name="${emailInputName}"]`);
+      const emailInput = element?.querySelector(createInputSelector(emailInputName));
 
       if (emailInput) {
         emailInput.value = emailConfig.defaultValue;
@@ -45,25 +68,4 @@ export const getExternalFormData = (formId) => {
   }
 
   return { ...formConfig.extraData };
-};
-
-const hideFieldInput = (fieldName, element) => {
-  const input = element.querySelector(`input[name="${fieldName}"]`);
-  if (input) {
-    input.style.display = 'none';
-  }
-};
-
-const hideFieldLabel = (fieldName, element) => {
-  const input = element?.querySelector(`input[name="${fieldName}"]`);
-
-  if (!input) {
-    return;
-  }
-
-  const label = input.parentElement?.querySelector('label');
-
-  if (label) {
-    label.style.display = 'none';
-  }
 };

--- a/src/utils/applyExternalFormConfig.js
+++ b/src/utils/applyExternalFormConfig.js
@@ -1,0 +1,70 @@
+export const getExternalFormConfig = (formId) => {
+  if (!window.SENDSAY_FORMS || !formId) {
+    return;
+  }
+
+  return window.SENDSAY_FORMS[formId];
+};
+
+export const applyExternalFormConfig = ({ element, formId }) => {
+  const formConfig = getExternalFormConfig(formId);
+
+  if (!formConfig) {
+    return;
+  }
+
+  if (formConfig.email) {
+    const emailConfig = formConfig.email;
+
+    // Set default value for email field
+    if (emailConfig.defaultValue !== undefined) {
+      const emailInputName = '_member_email';
+      const emailInput = element?.querySelector(`input[name="${emailInputName}"]`);
+
+      if (emailInput) {
+        emailInput.value = emailConfig.defaultValue;
+
+        emailInput.dispatchEvent(new Event('input', { bubbles: true }));
+      }
+
+      if (emailConfig.hideInput) {
+        hideFieldInput(emailInputName, element);
+      }
+
+      if (emailConfig.hideLabel) {
+        hideFieldLabel(emailInputName, element);
+      }
+    }
+  }
+};
+
+export const getExternalFormData = (formId) => {
+  const formConfig = getExternalFormConfig(formId);
+
+  if (!formConfig) {
+    return;
+  }
+
+  return { ...formConfig.extraData };
+};
+
+const hideFieldInput = (fieldName, element) => {
+  const input = element.querySelector(`input[name="${fieldName}"]`);
+  if (input) {
+    input.style.display = 'none';
+  }
+};
+
+const hideFieldLabel = (fieldName, element) => {
+  const input = element?.querySelector(`input[name="${fieldName}"]`);
+
+  if (!input) {
+    return;
+  }
+
+  const label = input.parentElement?.querySelector('label');
+
+  if (label) {
+    label.style.display = 'none';
+  }
+};

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -2,3 +2,4 @@ export { getHostName } from './getHostName';
 export { toNumber } from './toNumber';
 export { LeaveCounter } from './leaveCounter';
 export { extractId } from './extractId';
+export { applyExternalFormConfig, getExternalFormData } from './applyExternalFormConfig';

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -2,4 +2,4 @@ export { getHostName } from './getHostName';
 export { toNumber } from './toNumber';
 export { LeaveCounter } from './leaveCounter';
 export { extractId } from './extractId';
-export { applyExternalFormConfig, getExternalFormData } from './applyExternalFormConfig';
+export { applyExternalFormConfig } from './applyExternalFormConfig';


### PR DESCRIPTION
## Добавить в sendsay-forms возможность скрывать поле email и передавать дополнительные 

[fibery](https://sendsay.fibery.io/%D0%A0%D0%B0%D0%B7%D1%80%D0%B0%D0%B1%D0%BE%D1%82%D0%BA%D0%B0_app/%D0%97%D0%B0%D0%B4%D0%B0%D1%87%D0%B8/2954)

добавил возможность скрывать поле email и передавать дополнительные данные в форму с помощью стороннего конфига из объекта window.SENDSAY_FORMS

формат конфига:

```
window.SENDSAY_FORMS = {
    'formId': {
        email: {
            defaultValue: window.SENDSAY_USER['about.id'],
            hideInput: true,
            hideLabel: true,
        }
        extraData: { key: string, any }
    }
}
```